### PR TITLE
Fixed a crashing type conversion bug

### DIFF
--- a/Prototypes.js
+++ b/Prototypes.js
@@ -1738,7 +1738,7 @@ function SessionComponent(name, width, height, trackBank, _colors, mastertrack)
 		{
 			if(self._selectedTrack._clipslots[i].isPlaying)
 			{
-				self._cursorTrack.getClipLauncherSlots().select(i);
+				self._cursorTrack.getClipLauncherSlots().select(parseInt(i,10));
 				isPlaying = true;
 				break;
 			}
@@ -1749,7 +1749,7 @@ function SessionComponent(name, width, height, trackBank, _colors, mastertrack)
 			{
 				if(self._selectedTrack._clipslots[i].hasContent)
 				{
-					self._cursorTrack.getClipLauncherSlots().select(i);
+					self._cursorTrack.getClipLauncherSlots().select(parseInt(i,10));
 				}
 			}
 		}


### PR DESCRIPTION
The API expects an int, but for some reason i is a string like "3" in this context.